### PR TITLE
Support dynamic batch size in online_norm for tensorflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea
+online-norm/tensorflow/online_norm_tf.egg-info
+__pycache__


### PR DESCRIPTION
Currently in online_norm (not batch_online_norm) we store intermediate
outputs from forward pass for backward pass in a tensorflow variable. Tensorflow variables have fixed shape which makes it impossible to use one OnlineNorm layer in two places with different batch sizes.

In my use case (and I assume generally in Reinforcement Learning) I am using one tensorflow layers
with different batch sizes in two places - in policy rollouts and in policy updates. 

I noticed that `outputs` can be passed from forward to backward via reference (and not via mutable tensorflow variable).

In this PR I implement that change making OnlineNorm layer batch-size agnostic and getting rid of unnecessary b_dim argument.