### PR TITLE
make CUDA fwd one kernel instead of 7 small kernels for improved speed

### DIFF
--- a/online-norm/pytorch/README.md
+++ b/online-norm/pytorch/README.md
@@ -65,3 +65,9 @@ python setup.py test
 #### Added
 
 - Added CUDA kernel for online norm (removed python loop version of norm, deprecate BON)
+
+### 2020-05-20
+
+#### Added
+
+- make CUDA fwd one kernel instead of 7 small kernels for improved speed


### PR DESCRIPTION
Hey Atli,

This changes the ON CUDA implementation so that it calls one custom kernel instead of 6 torch kernels and one custom kernel.

Test: all tests still pass.

TODO: this update is for the PyTorch code and needs to be ported to TF code.